### PR TITLE
add generateRsaKeypair

### DIFF
--- a/src/generateEccKeyPair.ts
+++ b/src/generateEccKeyPair.ts
@@ -1,9 +1,5 @@
 import { promisifiedGenerateKeyPair } from './helpers';
-
-export interface KeyPair {
-  privateKey: string;
-  publicKey: string;
-}
+import { KeyPair } from './types';
 
 export async function generateEccKeyPair (): Promise<KeyPair> {
   const { publicKey, privateKey } = await promisifiedGenerateKeyPair(

--- a/src/generateRsaKeyPair.ts
+++ b/src/generateRsaKeyPair.ts
@@ -1,0 +1,14 @@
+import { promisifiedGenerateKeyPair } from './helpers';
+import { KeyPair } from './types';
+
+export async function generateRsaKeyPair (): Promise<KeyPair> {
+  const { publicKey, privateKey } = await promisifiedGenerateKeyPair(
+    'rsa',
+    {
+      modulusLength: 2048,
+      publicKeyEncoding: { type: 'pkcs1', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs1', format: 'pem' }
+    }
+  );
+  return { publicKey, privateKey };
+}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,4 @@
+export interface KeyPair {
+  privateKey: string;
+  publicKey: string;
+}

--- a/test/generateEccKeyPair.test.ts
+++ b/test/generateEccKeyPair.test.ts
@@ -1,6 +1,7 @@
 import * as helpers from '../src/helpers';
 
-import { generateEccKeyPair, KeyPair } from '../src/generateEccKeyPair';
+import { generateEccKeyPair } from '../src/generateEccKeyPair';
+import { KeyPair } from '../src/types';
 
 describe('generateEccKeypair', () => {
   let result: KeyPair;

--- a/test/generateRsaKeyPair.test.ts
+++ b/test/generateRsaKeyPair.test.ts
@@ -1,0 +1,27 @@
+import * as helpers from '../src/helpers';
+
+import { generateRsaKeyPair } from '../src/generateRsaKeyPair';
+import { KeyPair } from '../src/types';
+
+describe('generateRsaKeyPair', () => {
+  let keypair: KeyPair;
+
+  beforeEach(async () => {
+    jest.spyOn(helpers, 'promisifiedGenerateKeyPair');
+    keypair = await generateRsaKeyPair();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('generates an rsa keypair', () => {
+    expect(helpers.promisifiedGenerateKeyPair).toBeCalled();
+    expect((helpers.promisifiedGenerateKeyPair as jest.Mock).mock.calls[0][0]).toEqual('rsa');
+  });
+
+  it('returns the keypair', () => {
+    expect(keypair.privateKey).toBeDefined();
+    expect(keypair.publicKey).toBeDefined();
+  });
+});


### PR DESCRIPTION
[Ticket](https://trello.com/c/cHlbhiz7/472-crypto-lib-generate-rsa-keypair)

## Summary of Changes
- adds function to generate RSA keypairs
- adds tests

## Tests
- added unit tests for `generateRsaKeyPair`