### PR TITLE
convert raw keys to KeyObjects for sign/verify

### DIFF
--- a/build/sign.js
+++ b/build/sign.js
@@ -21,7 +21,12 @@ function sign(data, privateKey, encoding) {
     var decodedPrivateKey = helpers_1.decodeKey(privateKey, encoding);
     // convert to a Buffer and sign with private key
     var buf = Buffer.from(stringifiedData);
-    var signatureValueBuf = crypto_1.default.sign(null, buf, decodedPrivateKey);
+    // if we pass the key to crypto.sign as a buffer, it will assume pem format
+    // we need to convert it to a KeyObject first in order to use der formatted keys
+    var format = encoding === 'pem' ? 'pem' : 'der';
+    var type = encoding === 'pem' ? 'pkcs1' : 'pkcs8';
+    var privateKeyObj = crypto_1.default.createPrivateKey({ key: decodedPrivateKey, format: format, type: type });
+    var signatureValueBuf = crypto_1.default.sign(null, buf, privateKeyObj);
     // return resulting Buffer encoded as a base58 string
     return bs58_1.default.encode(signatureValueBuf);
 }

--- a/build/verify.js
+++ b/build/verify.js
@@ -25,8 +25,13 @@ function verify(signature, data, publicKey, encoding) {
     var dataBuf = Buffer.from(stringifiedData);
     // decode signature from base58 to a Buffer
     var signatureBuf = bs58_1.default.decode(signature);
+    // if we pass the key to crypto.verify as a buffer, it will assume pem format
+    // we need to convert it to a KeyObject first in order to use der formatted keys
+    var format = encoding === 'pem' ? 'pem' : 'der';
+    var type = encoding === 'pem' ? 'pkcs1' : 'spki';
+    var publicKeyObj = crypto_1.default.createPublicKey({ key: decodedPublicKey, format: format, type: type });
     // verifiy signature with the public key and return whether it succeeded
-    var result = crypto_1.default.verify(null, dataBuf, decodedPublicKey, signatureBuf);
+    var result = crypto_1.default.verify(null, dataBuf, publicKeyObj, signatureBuf);
     return result;
 }
 exports.verify = verify;

--- a/src/sign.ts
+++ b/src/sign.ts
@@ -18,7 +18,14 @@ export function sign (data: unknown, privateKey: string, encoding: 'base58' | 'p
 
   // convert to a Buffer and sign with private key
   const buf = Buffer.from(stringifiedData);
-  const signatureValueBuf = crypto.sign(null, buf, decodedPrivateKey);
+
+  // if we pass the key to crypto.sign as a buffer, it will assume pem format
+  // we need to convert it to a KeyObject first in order to use der formatted keys
+  const format = encoding === 'pem' ? 'pem' : 'der';
+  const type = encoding === 'pem' ? 'pkcs1' : 'pkcs8';
+
+  const privateKeyObj = crypto.createPrivateKey({ key: decodedPrivateKey, format, type });
+  const signatureValueBuf = crypto.sign(null, buf, privateKeyObj);
 
   // return resulting Buffer encoded as a base58 string
   return bs58.encode(signatureValueBuf);

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -23,7 +23,13 @@ export function verify (signature: string, data: unknown, publicKey: string, enc
   // decode signature from base58 to a Buffer
   const signatureBuf = bs58.decode(signature);
 
+  // if we pass the key to crypto.verify as a buffer, it will assume pem format
+  // we need to convert it to a KeyObject first in order to use der formatted keys
+  const format = encoding === 'pem' ? 'pem' : 'der';
+  const type = encoding === 'pem' ? 'pkcs1' : 'spki';
+  const publicKeyObj = crypto.createPublicKey({ key: decodedPublicKey, format, type });
+
   // verifiy signature with the public key and return whether it succeeded
-  const result = crypto.verify(null, dataBuf, decodedPublicKey, signatureBuf);
+  const result = crypto.verify(null, dataBuf, publicKeyObj, signatureBuf);
   return result;
 }

--- a/test/sign.test.ts
+++ b/test/sign.test.ts
@@ -23,11 +23,19 @@ describe('sign', () => {
   it('signs the data with the private key', () => {
     sign(data, privateKey);
     expect(crypto.sign).toBeCalled();
-    expect((crypto.sign as jest.Mock).mock.calls[0][2]).toEqual(privateKey);
+
+    const privateKeyObj = crypto.createPrivateKey(privateKey);
+    expect((crypto.sign as jest.Mock).mock.calls[0][2]).toEqual(privateKeyObj);
   });
 
   it('returns the signature', () => {
     const signature = sign(data, privateKey);
+    expect(signature).toBeDefined();
+  });
+
+  it('works with a base58 encoded key', async () => {
+    const base58KeyPair = await generateEccKeyPair('base58');
+    const signature = sign(data, base58KeyPair.privateKey, 'base58');
     expect(signature).toBeDefined();
   });
 });

--- a/test/verify.test.ts
+++ b/test/verify.test.ts
@@ -40,4 +40,11 @@ describe('verify', () => {
     const isVerified = verify(signature, invalidData, publicKey);
     expect(isVerified).toBe(false);
   });
+
+  it('works with a base58 encoded key', async () => {
+    const base58KeyPair = await generateEccKeyPair('base58');
+    signature = sign(data, base58KeyPair.privateKey, 'base58');
+    const isVerified = verify(signature, data, base58KeyPair.publicKey, 'base58');
+    expect(isVerified).toBe(true);
+  });
 });


### PR DESCRIPTION
[Ticket](https://trello.com/c/QbCLDxMy/625-sign-and-verify-operations-do-not-work-with-base58-keys)

## Summary of Changes
- `sign` and `verify` now convert keys to KeyObjects before performing crypto operations with them